### PR TITLE
feat: Make cart closable and position in top-right

### DIFF
--- a/app/components/cart-popup.tsx
+++ b/app/components/cart-popup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 interface CartProduct {
   id: number;
@@ -22,12 +22,29 @@ interface CartData {
 
 interface CartPopupProps {
   isOpen: boolean;
+  onClose: () => void; // Add this line
 }
 
-const CartPopup: React.FC<CartPopupProps> = ({ isOpen }) => {
+const CartPopup: React.FC<CartPopupProps> = ({ isOpen, onClose }) => {
   const [cartData, setCartData] = useState<CartData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (popupRef.current && !popupRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onClose]);
 
   useEffect(() => {
     if (isOpen) {
@@ -68,11 +85,20 @@ const CartPopup: React.FC<CartPopupProps> = ({ isOpen }) => {
 
   return (
     <div
-      className={`fixed inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center z-50 transition-opacity duration-300 ${
+      className={`fixed top-20 right-4 z-40 transition-opacity duration-300 ${
         isOpen ? 'opacity-100' : 'opacity-0 hidden'
       }`}
     >
-      <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+      <div ref={popupRef} className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md relative"> {/* Added position: relative */}
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+          aria-label="Close cart"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
         <h2 className="text-2xl font-semibold mb-4">Your Cart</h2>
         <div className="mb-4 min-h-[100px]"> {/* Added min-h for consistent size */}
           {isLoading && <p className="text-gray-700">Loading...</p>}

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -11,6 +11,10 @@ export function Header() {
   const toggleCartPopup = () => {
     setIsCartPopupOpen(!isCartPopupOpen);
   };
+
+  const closeCartPopup = () => {
+    setIsCartPopupOpen(false);
+  };
   const { cartState } = useCart();
   const totalQuantity = cartState.totalQuantity;
 
@@ -74,7 +78,7 @@ export function Header() {
           )}
         </button>
       </header>
-      <CartPopup isOpen={isCartPopupOpen} />
+      <CartPopup isOpen={isCartPopupOpen} onClose={closeCartPopup} />
     </>
   );
 }


### PR DESCRIPTION
I've implemented the following changes to the cart functionality:

-   **Closable Cart:**
    -   I added a close button ("X") within the cart popup.
    -   I implemented "click outside to close" functionality for the cart.
    -   The `Header` component now manages and provides the close handler to the `CartPopup`.

-   **Styling and Positioning:**
    -   The cart popup is now positioned in the top-right corner of the viewport.
    -   I removed the modal overlay, allowing the rest of the page to be visible and interactive when the cart is open.
    -   I adjusted z-index to ensure proper stacking with the header.

These changes address the issue of the cart not being closable and improve its user experience by making it a non-modal element.